### PR TITLE
chore: Removed vercel.json

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -343,6 +343,7 @@ NOTE: These were adapted from the default wails `vue` template and modified to u
 * `README.md`
 * `public/favicon.ico`
 * `.vscode/`
+* `vercel.json`
 
 **Removed the following entries from `.gitignore`:**
 * `.idea`

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,9 +1,0 @@
-{
-    "rewrites": [
-        {
-            "source": "/:path*",
-            "destination": "/index.html"
-        }
-    ],
-    "trailingSlash": false
-}


### PR DESCRIPTION
Removing the vercel.json file;  It was oversight from the original cleanup steps.

doc: Updates README to add vercel.json to list of deleted files